### PR TITLE
fix: Selected address fix

### DIFF
--- a/app/src/main/java/com/metamask/dapp/EthereumViewModel.kt
+++ b/app/src/main/java/com/metamask/dapp/EthereumViewModel.kt
@@ -24,8 +24,8 @@ class EthereumViewModel @Inject constructor(
                     Logger.log("Ethereum connection error: ${result.error.message}")
                     onError(result.error.message)
                 }
-                is Result.Success.Item -> {
-                    Logger.log("Ethereum connection result: ${result.value}")
+                is Result.Success.Items -> {
+                    Logger.log("Ethereum connection result: ${result.value.first()}")
                     onSuccess()
                 }
                 else -> { }

--- a/metamask-android-sdk/build.gradle
+++ b/metamask-android-sdk/build.gradle
@@ -15,7 +15,7 @@ android {
         targetSdk 33
 
         ext.versionCode = 1
-        ext.versionName = "0.5.4"
+        ext.versionName = "0.5.5"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
@@ -62,7 +62,7 @@ dependencies {
 
 ext {
     PUBLISH_GROUP_ID = 'io.metamask.androidsdk'
-    PUBLISH_VERSION = '0.5.4'
+    PUBLISH_VERSION = '0.5.5'
     PUBLISH_ARTIFACT_ID = 'metamask-android-sdk'
 }
 

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/CommunicationClient.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/CommunicationClient.kt
@@ -8,8 +8,6 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
-import android.util.Log
-import androidx.annotation.RequiresApi
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import io.metamask.nativesdk.IMessegeService
@@ -258,6 +256,7 @@ internal class CommunicationClient(context: Context, callback: EthereumEventCall
                 val account = accounts.firstOrNull()
 
                 if (account != null) {
+                    Logger.error("CommunicationClient:: Response: Updated to account $account")
                     updateAccount(account)
                     completeRequest(id, Result.Success.Item(account))
                 }
@@ -272,14 +271,8 @@ internal class CommunicationClient(context: Context, callback: EthereumEventCall
             EthereumMethod.ETH_REQUEST_ACCOUNTS.value  -> {
                 val result = data.optString("result")
                 val accounts: List<String> = Gson().fromJson(result, object : TypeToken<List<String>>() {}.type)
-                val account = accounts.getOrNull(0)
 
-                if (account != null) {
-                    updateAccount(account)
-                    completeRequest(id, Result.Success.Item(account))
-                } else {
-                    Logger.error("CommunicationClient:: Request accounts failure: $result")
-                }
+                completeRequest(id, Result.Success.Items(accounts))
             }
             EthereumMethod.ETH_CHAIN_ID.value -> {
                 val chainId = data.optString("result")
@@ -345,6 +338,7 @@ internal class CommunicationClient(context: Context, callback: EthereumEventCall
                 val accountsJson = event.optString("params")
                 val accounts: List<String> = Gson().fromJson(accountsJson, object : TypeToken<List<String>>() {}.type)
                 accounts.getOrNull(0)?.let { account ->
+                    Logger.error("CommunicationClient:: Event Updated to account $account")
                     updateAccount(account)
                 }
             }

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/SDKInfo.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/SDKInfo.kt
@@ -1,6 +1,6 @@
 package io.metamask.androidsdk
 
 object SDKInfo {
-    const val VERSION = "0.5.4"
+    const val VERSION = "0.5.5"
     const val PLATFORM = "android"
 }


### PR DESCRIPTION
This PR fixes the selected address whereby the wallet has more than one account and the selected address is not the first one `eth_requestAccounts` always returns the accounts in the same order rather than the selected one first. So when the selected address was not the first address the SDK had the incorrect account as selected.