### PR TITLE
fix: restore session persistence

### DIFF
--- a/metamask-android-sdk/build.gradle
+++ b/metamask-android-sdk/build.gradle
@@ -15,7 +15,7 @@ android {
         targetSdk 33
 
         ext.versionCode = 1
-        ext.versionName = "0.5.5"
+        ext.versionName = "0.5.6"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
@@ -62,7 +62,7 @@ dependencies {
 
 ext {
     PUBLISH_GROUP_ID = 'io.metamask.androidsdk'
-    PUBLISH_VERSION = '0.5.5'
+    PUBLISH_VERSION = '0.5.6'
     PUBLISH_ARTIFACT_ID = 'metamask-android-sdk'
 }
 

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/CommunicationClient.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/CommunicationClient.kt
@@ -267,9 +267,14 @@ internal class CommunicationClient(context: Context, callback: EthereumEventCall
                     completeRequest(id, Result.Success.Item(chainId))
                 }
             }
-            EthereumMethod.ETH_REQUEST_ACCOUNTS.value  -> {
+            EthereumMethod.ETH_REQUEST_ACCOUNTS.value -> {
                 val result = data.optString("result")
                 val accounts: List<String> = Gson().fromJson(result, object : TypeToken<List<String>>() {}.type)
+                val selectedAccount = accounts.getOrNull(0)
+
+                if (selectedAccount != null) {
+                    updateAccount(selectedAccount)
+                }
 
                 completeRequest(id, Result.Success.Items(accounts))
             }

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/SDKInfo.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/SDKInfo.kt
@@ -1,6 +1,6 @@
 package io.metamask.androidsdk
 
 object SDKInfo {
-    const val VERSION = "0.5.5"
+    const val VERSION = "0.5.6"
     const val PLATFORM = "android"
 }


### PR DESCRIPTION
This PR fixes the scenario whereby on reconnection the SDK was not updating the selected account from the `eth_requestAccounts` response. This regression was introduced in #116 when fixing the selected address when multiple accounts are connected on the wallet. This latter issue has been fixed in [this](https://github.com/MetaMask/metamask-mobile/pull/10213) wallet PR