### PR TITLE
chore: log done request for all responses

### DIFF
--- a/metamask-android-sdk/build.gradle
+++ b/metamask-android-sdk/build.gradle
@@ -15,7 +15,7 @@ android {
         targetSdk 33
 
         ext.versionCode = 1
-        ext.versionName = "0.5.6"
+        ext.versionName = "0.5.7"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
@@ -62,7 +62,7 @@ dependencies {
 
 ext {
     PUBLISH_GROUP_ID = 'io.metamask.androidsdk'
-    PUBLISH_VERSION = '0.5.6'
+    PUBLISH_VERSION = '0.5.7'
     PUBLISH_ARTIFACT_ID = 'metamask-android-sdk'
 }
 

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/CommunicationClient.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/CommunicationClient.kt
@@ -209,7 +209,7 @@ internal class CommunicationClient(context: Context, callback: EthereumEventCall
 
     private fun handleResponse(id: String, data: JSONObject) {
         val submittedRequest = submittedRequests[id]?.request ?: return
-        
+
         val error = data.optString("error")
 
         val params = mapOf(

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/CommunicationClient.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/CommunicationClient.kt
@@ -208,13 +208,20 @@ internal class CommunicationClient(context: Context, callback: EthereumEventCall
     }
 
     private fun handleResponse(id: String, data: JSONObject) {
+        val submittedRequest = submittedRequests[id]?.request ?: return
+        
         val error = data.optString("error")
+
+        val params = mapOf(
+            "method" to submittedRequest.method,
+            "from" to "mobile"
+        )
+        trackEvent(Event.SDK_RPC_REQUEST_DONE, params)
 
         if (handleError(error, id)) {
             return
         }
 
-        val submittedRequest = submittedRequests[id]?.request ?: return
         val isResultMethod = EthereumMethod.isResultMethod(submittedRequest.method)
 
         if (!isResultMethod) {
@@ -239,12 +246,6 @@ internal class CommunicationClient(context: Context, callback: EthereumEventCall
             }
             return
         }
-
-        val params = mapOf(
-            "method" to submittedRequest.method,
-            "from" to "mobile"
-        )
-        trackEvent(Event.SDK_RPC_REQUEST_DONE, params)
 
         when(submittedRequest.method) {
             EthereumMethod.GET_METAMASK_PROVIDER_STATE.value -> {

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/SDKInfo.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/SDKInfo.kt
@@ -1,6 +1,6 @@
 package io.metamask.androidsdk
 
 object SDKInfo {
-    const val VERSION = "0.5.6"
+    const val VERSION = "0.5.7"
     const val PLATFORM = "android"
 }


### PR DESCRIPTION
This PR ensures that all request-response events are logged for `SDK_RPC_REQUEST_DONE`. Previously, only success responses were logged.