### PR TITLE
chore: downgrade compileSdk version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 
 android {
     namespace 'com.metamask.dapp'
-    compileSdk 34
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.metamask.dapp"
         minSdk 23
-        targetSdk 34
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 

--- a/app/src/main/java/com/metamask/dapp/AppModule.kt
+++ b/app/src/main/java/com/metamask/dapp/AppModule.kt
@@ -18,9 +18,14 @@ internal object AppModule {
         return DappMetadata("Droiddapp", "https://droiddapp.io", iconUrl = "https://cdn.sstatic.net/Sites/stackoverflow/Img/apple-touch-icon.png")
     }
 
+    @Provides
+    fun provideLogger(): Logger {
+        return DefaultLogger
+    }
+
     @Provides // Add SDKOptions(infuraAPIKey="supply_your_key_here") to Ethereum constructor for read-only calls
-    fun provideEthereum(@ApplicationContext context: Context, dappMetadata: DappMetadata): Ethereum {
-        return Ethereum(context, dappMetadata, SDKOptions(infuraAPIKey = "#####"))
+    fun provideEthereum(@ApplicationContext context: Context, dappMetadata: DappMetadata, logger: Logger): Ethereum {
+        return Ethereum(context, dappMetadata, SDKOptions(infuraAPIKey = "#####"), logger)
     }
 
     @Provides

--- a/app/src/main/java/com/metamask/dapp/EthereumFlowViewModel.kt
+++ b/app/src/main/java/com/metamask/dapp/EthereumFlowViewModel.kt
@@ -110,8 +110,6 @@ class EthereumFlowViewModel @Inject constructor(
     }
 
     suspend fun addEthereumChain(chainId: String) : SwitchChainResult {
-        Logger.log("Adding chainId: $chainId")
-
         return when (val result = ethereum.addEthereumChain(
             chainId = chainId,
             chainName = Network.chainNameFor(chainId),

--- a/app/src/main/java/com/metamask/dapp/EthereumViewModel.kt
+++ b/app/src/main/java/com/metamask/dapp/EthereumViewModel.kt
@@ -8,7 +8,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class EthereumViewModel @Inject constructor(
-    private val ethereum: Ethereum
+    private val ethereum: Ethereum,
+    private val logger: Logger = DefaultLogger
     ): ViewModel() {
 
     val ethereumState = MediatorLiveData<EthereumState>().apply {
@@ -21,11 +22,11 @@ class EthereumViewModel @Inject constructor(
         ethereum.connect() { result ->
             when (result) {
                 is Result.Error -> {
-                    Logger.log("Ethereum connection error: ${result.error.message}")
+                    logger.log("Ethereum connection error: ${result.error.message}")
                     onError(result.error.message)
                 }
                 is Result.Success.Items -> {
-                    Logger.log("Ethereum connection result: ${result.value.first()}")
+                    logger.log("Ethereum connection result: ${result.value.first()}")
                     onSuccess()
                 }
                 else -> { }
@@ -37,11 +38,11 @@ class EthereumViewModel @Inject constructor(
         ethereum.connectWith(request) { result ->
             when (result) {
                 is Result.Error -> {
-                    Logger.log("Connectwith error: ${result.error.message}")
+                    logger.log("Connectwith error: ${result.error.message}")
                     onError(result.error.message)
                 }
                 is Result.Success.Item -> {
-                    Logger.log("Connectwith result: $result")
+                    logger.log("Connectwith result: $result")
                     onSuccess(result.value)
                 }
                 else -> {}
@@ -72,11 +73,11 @@ class EthereumViewModel @Inject constructor(
         ethereum.connectSign(message) { result ->
             when (result) {
                 is Result.Error -> {
-                    Logger.log("Connect & sign error: ${result.error.message}")
+                    logger.log("Connect & sign error: ${result.error.message}")
                     onError(result.error.message)
                 }
                 is Result.Success.Item -> {
-                    Logger.log("Connect & sign  result: $result")
+                    logger.log("Connect & sign  result: $result")
                     onSuccess(result.value)
                 }
                 else -> {}
@@ -110,11 +111,11 @@ class EthereumViewModel @Inject constructor(
         ethereum.sendRequestBatch(requestBatch) { result ->
             when (result) {
                 is Result.Error -> {
-                    Logger.log("Ethereum batch sign error: ${result.error.message}")
+                    logger.log("Ethereum batch sign error: ${result.error.message}")
                     onError(result.error.message)
                 }
                 is Result.Success.Items -> {
-                    Logger.log("Ethereum batch sign result: $result")
+                    logger.log("Ethereum batch sign result: $result")
                     onSuccess(result.value)
                 }
                 else -> {}
@@ -138,11 +139,11 @@ class EthereumViewModel @Inject constructor(
         ethereum.sendRequest(signRequest) { result ->
             when (result) {
                 is Result.Error -> {
-                    Logger.log("Ethereum sign error: ${result.error.message}")
+                    logger.log("Ethereum sign error: ${result.error.message}")
                     onError(result.error.message)
                 }
                 is Result.Success.Item -> {
-                    Logger.log("Ethereum sign result: $result")
+                    logger.log("Ethereum sign result: $result")
                     onSuccess(result.value)
                 }
                 else -> {}
@@ -165,11 +166,11 @@ class EthereumViewModel @Inject constructor(
         ethereum.sendRequest(getBalanceRequest) { result ->
             when (result) {
                 is Result.Error -> {
-                    Logger.log("Ethereum get balance error: ${result.error.message}")
+                    logger.log("Ethereum get balance error: ${result.error.message}")
                     onError(result.error.message)
                 }
                 is Result.Success.Item -> {
-                    Logger.log("Ethereum get balance result: $result")
+                    logger.log("Ethereum get balance result: $result")
                     onSuccess(result.value)
                 }
                 else -> {}
@@ -191,11 +192,11 @@ class EthereumViewModel @Inject constructor(
         ethereum.sendRequest(gasPriceRequest) { result ->
             when (result) {
                 is Result.Error -> {
-                    Logger.log("Ethereum gas price error: ${result.error.message}")
+                    logger.log("Ethereum gas price error: ${result.error.message}")
                     onError(result.error.message)
                 }
                 is Result.Success.Item -> {
-                    Logger.log("Ethereum gas price result: $result")
+                    logger.log("Ethereum gas price result: $result")
                     onSuccess(result.value)
                 }
                 else -> {}
@@ -217,11 +218,11 @@ class EthereumViewModel @Inject constructor(
         ethereum.sendRequest(web3ClientVersionRequest) { result ->
             when (result) {
                 is Result.Error -> {
-                    Logger.log("Ethereum web3 client version error: ${result.error.message}")
+                    logger.log("Ethereum web3 client version error: ${result.error.message}")
                     onError(result.error.message)
                 }
                 is Result.Success.Item -> {
-                    Logger.log("Ethereum web3 client version result: $result")
+                    logger.log("Ethereum web3 client version result: $result")
                     onSuccess(result.value)
                 }
                 else -> {}
@@ -250,11 +251,11 @@ class EthereumViewModel @Inject constructor(
         ethereum.sendRequest(transactionRequest) { result ->
             when (result) {
                 is Result.Error -> {
-                    Logger.log("Ethereum transaction error: ${result.error.message}")
+                    logger.log("Ethereum transaction error: ${result.error.message}")
                     onError(result.error.message)
                 }
                 is Result.Success.Item -> {
-                    Logger.log("Ethereum transaction result: $result")
+                    logger.log("Ethereum transaction result: $result")
                     onSuccess(result.value)
                 }
                 else -> {}
@@ -307,7 +308,7 @@ class EthereumViewModel @Inject constructor(
         onSuccess: (message: String) -> Unit,
         onError: (message: String) -> Unit
     ) {
-        Logger.log("Adding chainId: $chainId")
+        logger.log("Adding chainId: $chainId")
 
         val addChainParams: Map<String, Any> = mapOf(
             "chainId" to chainId,

--- a/app/src/main/java/com/metamask/dapp/ScreenViewModel.kt
+++ b/app/src/main/java/com/metamask/dapp/ScreenViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.metamask.androidsdk.DefaultLogger
 import io.metamask.androidsdk.Logger
 import javax.inject.Inject
 
@@ -14,6 +15,6 @@ class ScreenViewModel @Inject constructor(): ViewModel() {
 
     fun setScreen(screen: DappScreen) {
         _currentScreen.value = screen
-        Logger.log("Navigating to $screen")
+        DefaultLogger.log("Navigating to $screen")
     }
 }

--- a/metamask-android-sdk/build.gradle
+++ b/metamask-android-sdk/build.gradle
@@ -15,7 +15,7 @@ android {
         targetSdk 33
 
         ext.versionCode = 1
-        ext.versionName = "0.5.7"
+        ext.versionName = "0.5.8"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
@@ -65,7 +65,7 @@ dependencies {
 
 ext {
     PUBLISH_GROUP_ID = 'io.metamask.androidsdk'
-    PUBLISH_VERSION = '0.5.7'
+    PUBLISH_VERSION = '0.5.8'
     PUBLISH_ARTIFACT_ID = 'metamask-android-sdk'
 }
 

--- a/metamask-android-sdk/build.gradle
+++ b/metamask-android-sdk/build.gradle
@@ -8,11 +8,11 @@ plugins {
 
 android {
     namespace 'io.metamask.androidsdk'
-    compileSdk 34
+    compileSdk 33
 
     defaultConfig {
         minSdk 23
-        targetSdk 34
+        targetSdk 33
 
         ext.versionCode = 1
         ext.versionName = "0.5.7"
@@ -54,7 +54,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.test.ext:junit-ktx:1.1.5'
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.7.0"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.6.1"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0'

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/SDKInfo.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/SDKInfo.kt
@@ -1,6 +1,6 @@
 package io.metamask.androidsdk
 
 object SDKInfo {
-    const val VERSION = "0.5.7"
+    const val VERSION = "0.5.8"
     const val PLATFORM = "android"
 }

--- a/metamask-android-sdk/src/test/java/io/metamask/androidsdk/SessionManagerTests.kt
+++ b/metamask-android-sdk/src/test/java/io/metamask/androidsdk/SessionManagerTests.kt
@@ -1,6 +1,8 @@
 package io.metamask.androidsdk
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -24,6 +26,7 @@ class SessionManagerTests {
         sessionManager = SessionManager(store = keyStorage, logger = TestLogger)
         sessionManager.clearSession{}
     }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testInitLoadsSessionConfig() = runTest {
@@ -53,10 +56,10 @@ class SessionManagerTests {
     }
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun testSessionConfigReset() = runTest {
+    fun testSessionConfigReset() = runBlocking {
         val initialSessionConfig = sessionManager.getSessionConfig()
+        delay(1000)
         val resetSessionConfig = sessionManager.getSessionConfig(reset = true)
-        advanceUntilIdle()
 
         assertNotEquals(initialSessionConfig.sessionId, resetSessionConfig.sessionId)
     }

--- a/metamask-android-sdk/src/test/java/io/metamask/androidsdk/SessionManagerTests.kt
+++ b/metamask-android-sdk/src/test/java/io/metamask/androidsdk/SessionManagerTests.kt
@@ -37,7 +37,7 @@ class SessionManagerTests {
     fun testDefaultSessionDuration() = runTest {
         val sessionConfig = sessionManager.getSessionConfig()
         val defaultDuration = 30 * 24 * 3600L // 30 days
-        assertEquals(sessionConfig.expiryDate, System.currentTimeMillis() + defaultDuration * 1000)
+        assertEquals(sessionConfig.expiryDate/1000, System.currentTimeMillis()/1000 + defaultDuration)
     }
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
@@ -46,7 +46,7 @@ class SessionManagerTests {
         sessionManager.updateSessionDuration(newDuration)
         advanceUntilIdle()
         val sessionConfig = sessionManager.getSessionConfig()
-        assertEquals(sessionConfig.expiryDate/1000, System.currentTimeMillis()/1000L + newDuration)
+        assertEquals(sessionConfig.expiryDate/1000, System.currentTimeMillis()/1000 + newDuration)
     }
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test

--- a/metamask-android-sdk/src/test/java/io/metamask/androidsdk/SessionManagerTests.kt
+++ b/metamask-android-sdk/src/test/java/io/metamask/androidsdk/SessionManagerTests.kt
@@ -24,10 +24,12 @@ class SessionManagerTests {
         sessionManager = SessionManager(store = keyStorage, logger = TestLogger)
         sessionManager.clearSession{}
     }
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testInitLoadsSessionConfig() = runTest {
         assertNotNull(sessionManager.sessionId)
     }
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testDefaultSessionDuration() = runTest {
         val sessionConfig = sessionManager.getSessionConfig()
@@ -43,6 +45,7 @@ class SessionManagerTests {
         val sessionConfig = sessionManager.getSessionConfig()
         assertEquals(sessionConfig.expiryDate/1000, System.currentTimeMillis()/1000L + newDuration)
     }
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testSessionConfigIsValid() = runTest {
         val sessionConfig = sessionManager.getSessionConfig()
@@ -57,6 +60,7 @@ class SessionManagerTests {
 
         assertNotEquals(initialSessionConfig.sessionId, resetSessionConfig.sessionId)
     }
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testSaveSessionConfig() = runTest {
         val sessionConfig = SessionConfig("test_session", System.currentTimeMillis() + 1000L)
@@ -75,6 +79,7 @@ class SessionManagerTests {
         assertNotEquals("", sessionManager.sessionId)
         assertNotEquals("", sessionConfig.sessionId)
     }
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testMakeNewSessionConfig() = runTest {
         val newConfig = sessionManager.makeNewSessionConfig()

--- a/metamask-android-sdk/src/test/java/io/metamask/androidsdk/SessionManagerTests.kt
+++ b/metamask-android-sdk/src/test/java/io/metamask/androidsdk/SessionManagerTests.kt
@@ -12,13 +12,17 @@ import org.junit.Test
 
 class SessionManagerTests {
     private val sessionConfigFile: String = "SESSION_CONFIG_FILE"
+    private val sessionConfigKey: String = "SESSION_CONFIG_KEY"
+
     private lateinit var keyStorage: SecureStorage
     private lateinit var sessionManager: SessionManager
     @Before
     fun setUp() {
         keyStorage = MockKeyStorage()
+        keyStorage.clearValue(key = sessionConfigKey, file = sessionConfigFile)
         keyStorage.clear(sessionConfigFile)
         sessionManager = SessionManager(store = keyStorage, logger = TestLogger)
+        sessionManager.clearSession{}
     }
     @Test
     fun testInitLoadsSessionConfig() = runTest {
@@ -44,10 +48,12 @@ class SessionManagerTests {
         val sessionConfig = sessionManager.getSessionConfig()
         assertTrue(sessionConfig.isValid())
     }
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testSessionConfigReset() = runTest {
         val initialSessionConfig = sessionManager.getSessionConfig()
         val resetSessionConfig = sessionManager.getSessionConfig(reset = true)
+        advanceUntilIdle()
 
         assertNotEquals(initialSessionConfig.sessionId, resetSessionConfig.sessionId)
     }

--- a/metamask-android-sdk/src/test/java/io/metamask/androidsdk/SessionManagerTests.kt
+++ b/metamask-android-sdk/src/test/java/io/metamask/androidsdk/SessionManagerTests.kt
@@ -37,7 +37,7 @@ class SessionManagerTests {
         sessionManager.updateSessionDuration(newDuration)
         advanceUntilIdle()
         val sessionConfig = sessionManager.getSessionConfig()
-        assertEquals(sessionConfig.expiryDate, System.currentTimeMillis() + newDuration * 1000)
+        assertEquals(sessionConfig.expiryDate/1000, System.currentTimeMillis()/1000L + newDuration)
     }
     @Test
     fun testSessionConfigIsValid() = runTest {


### PR DESCRIPTION
This PR 
• Reverts compileSdk version upgrade back to 33
• Downgrades `lifecycle-livedata-ktx` to `2.6.1` to be suited for version 33 of the Android APIs 