### PR TITLE
chore: satinise batch request response to remove null values

### DIFF
--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/CommunicationClient.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/CommunicationClient.kt
@@ -300,8 +300,9 @@ internal class CommunicationClient(context: Context, callback: EthereumEventCall
             }
             EthereumMethod.METAMASK_BATCH.value -> {
                 val result = data.optString("result")
-                val results: List<String> = Gson().fromJson(result, object : TypeToken<List<String>>() {}.type)
-                completeRequest(id, Result.Success.Items(results))
+                val results: List<String?> = Gson().fromJson(result, object : TypeToken<List<String?>>() {}.type)
+                val sanitisedResults = results.filterNotNull()
+                completeRequest(id, Result.Success.Items(sanitisedResults))
             }
             else -> {
                 val result = data.optString("result")


### PR DESCRIPTION
A batch request with RPCs to switch network & sign has a response like this: `[null, 0xbf015fa2fed401e18...]` because the result for switching a chain is `null` (unfortunately). This PR satinises the response to remove null values