### PR TITLE
feat: Add an option label prefix for the example dapp to make testing easier

### DIFF
--- a/app/src/main/java/com/metamask/dapp/DappActionsScreen.kt
+++ b/app/src/main/java/com/metamask/dapp/DappActionsScreen.kt
@@ -36,7 +36,15 @@ fun DappActionsScreen(
             Heading("Dapp Actions")
 
             DappLabel(
+                labelPrefix = "Account:",
                 text = ethereumState.selectedAddress,
+                color = Color.Unspecified,
+                modifier = Modifier.padding(bottom = 36.dp)
+            )
+
+            DappLabel(
+                labelPrefix = "ChainId:",
+                text = ethereumState.chainId,
                 color = Color.Unspecified,
                 modifier = Modifier.padding(bottom = 36.dp)
             )

--- a/app/src/main/java/com/metamask/dapp/DappActionsScreen.kt
+++ b/app/src/main/java/com/metamask/dapp/DappActionsScreen.kt
@@ -36,14 +36,14 @@ fun DappActionsScreen(
             Heading("Dapp Actions")
 
             DappLabel(
-                labelPrefix = "Account:",
+                heading = "Account:",
                 text = ethereumState.selectedAddress,
                 color = Color.Unspecified,
                 modifier = Modifier.padding(bottom = 36.dp)
             )
 
             DappLabel(
-                labelPrefix = "ChainId:",
+                heading = "ChainId:",
                 text = ethereumState.chainId,
                 color = Color.Unspecified,
                 modifier = Modifier.padding(bottom = 36.dp)

--- a/app/src/main/java/com/metamask/dapp/DappLabel.kt
+++ b/app/src/main/java/com/metamask/dapp/DappLabel.kt
@@ -12,17 +12,17 @@ import androidx.compose.ui.unit.sp
 
 @Composable
 fun DappLabel(
-    labelPrefix: String = "",
+    heading: String = "",
     text: String,
     color: Color = Color.White,
     fontSize: TextUnit = 14.sp,
     modifier: Modifier = Modifier.padding(bottom = 12.dp)
 ) {
-    if (labelPrefix.isNotEmpty()) {
+    if (heading.isNotEmpty()) {
         Text(
-            text = labelPrefix,
+            text = heading,
             color = color,
-            fontSize = fontSize.times(1.3),
+            fontSize = 18.sp,
             modifier = Modifier.padding(bottom = 5.dp)
         )
     }

--- a/app/src/main/java/com/metamask/dapp/DappLabel.kt
+++ b/app/src/main/java/com/metamask/dapp/DappLabel.kt
@@ -12,11 +12,20 @@ import androidx.compose.ui.unit.sp
 
 @Composable
 fun DappLabel(
+    labelPrefix: String = "",
     text: String,
     color: Color = Color.White,
     fontSize: TextUnit = 14.sp,
     modifier: Modifier = Modifier.padding(bottom = 12.dp)
 ) {
+    if (labelPrefix.isNotEmpty()) {
+        Text(
+            text = labelPrefix,
+            color = color,
+            fontSize = fontSize.times(1.3),
+            modifier = Modifier.padding(bottom = 5.dp)
+        )
+    }
     Text(
         text = text,
         color = color,


### PR DESCRIPTION
This PR aims to provide and easier way of distinguishing the chainId in the Dapp actions screen.

After:
![Screenshot 2024-07-24 at 15 32 00](https://github.com/user-attachments/assets/3386cd02-9f57-415a-8bb9-7efe340bff6b)
