### PR TITLE
chore: send transaction fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ code to your project file:
 @AndroidEntryPoint
 class SomeModel(context: Context) {
     
-    val dappMetadata = DappMetadata("Droid Dapp", "")
+    val dappMetadata = DappMetadata("Droid Dapp", "https://www.droiddapp.io")
     val infuraAPIKey = "1234567890" // We use Infura API for read-only RPCs for a seamless user experience 
     
     // A) Using callbacks

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ code to your project file:
 @AndroidEntryPoint
 class SomeModel(context: Context) {
     
-    val dappMetadata = DappMetadata("Droid Dapp", "https://droiddapp.com")
+    val dappMetadata = DappMetadata("Droid Dapp", "")
     val infuraAPIKey = "1234567890" // We use Infura API for read-only RPCs for a seamless user experience 
     
     // A) Using callbacks

--- a/README.md
+++ b/README.md
@@ -255,10 +255,10 @@ The following example sends a transaction by calling
 // Create parameters
 val from = ethereum.selectedAddress
 val to = "0x0000000000000000000000000000000000000000"
-val amount = "0x01"
+val value = "0x8ac7230489e80000"
 
 // Make a transaction request
-when (val result = ethereum.sendTransaction(from, to, amount)) {
+when (val result = ethereum.sendTransaction(from, to, value)) {
     is Result.Success.Item -> {
         Logger.log("Ethereum transaction result: ${result.value}")
         balance = result.value
@@ -302,7 +302,7 @@ We have provided a convenience method that enables you to connect and make any r
 val params: Map<String, Any> = mutableMapOf(
     "from" to "", // this will be populated with selected address once connected
     "to" to "0x0000000000000000000000000000000000000000",
-    "amount" to "0x01"
+    "value" to "0x8ac7230489e80000"
 )
 
 val transactionRequest = EthereumRequest(

--- a/app/src/main/java/com/metamask/dapp/AppModule.kt
+++ b/app/src/main/java/com/metamask/dapp/AppModule.kt
@@ -15,7 +15,7 @@ import io.metamask.androidsdk.*
 internal object AppModule {
     @Provides
     fun provideDappMetadata(): DappMetadata {
-        return DappMetadata("Droiddapp", "https://droiddapp.io", iconUrl = "https://cdn.sstatic.net/Sites/stackoverflow/Img/apple-touch-icon.png")
+        return DappMetadata("Droiddapp", "https://www.droiddapp.io", iconUrl = "https://cdn.sstatic.net/Sites/stackoverflow/Img/apple-touch-icon.png")
     }
 
     @Provides

--- a/app/src/main/java/com/metamask/dapp/EthereumViewModel.kt
+++ b/app/src/main/java/com/metamask/dapp/EthereumViewModel.kt
@@ -50,7 +50,7 @@ class EthereumViewModel @Inject constructor(
         }
     }
 
-    fun connectWithSendTransaction(amount: String,
+    fun connectWithSendTransaction(value: String,
                         from: String,
                         to: String,
                         onSuccess: (Any?) -> Unit,
@@ -58,7 +58,7 @@ class EthereumViewModel @Inject constructor(
         val params: MutableMap<String, Any> = mutableMapOf(
             "from" to from,
             "to" to to,
-            "amount" to amount
+            "value" to value
         )
 
         val transactionRequest = EthereumRequest(
@@ -231,7 +231,7 @@ class EthereumViewModel @Inject constructor(
     }
 
     fun sendTransaction(
-        amount: String,
+        value: String,
         from: String,
         to: String,
         onSuccess: (String) -> Unit,
@@ -240,7 +240,7 @@ class EthereumViewModel @Inject constructor(
         val params: MutableMap<String, Any> = mutableMapOf(
             "from" to from,
             "to" to to,
-            "amount" to amount
+            "value" to value
         )
 
         val transactionRequest = EthereumRequest(

--- a/app/src/main/java/com/metamask/dapp/SendTransactionScreen.kt
+++ b/app/src/main/java/com/metamask/dapp/SendTransactionScreen.kt
@@ -34,8 +34,8 @@ fun SendTransactionScreen(
     navController: NavController,
     ethereumState: EthereumState,
     isConnectWith: Boolean = false,
-    sendTransaction: suspend (amount: String, from: String, to: String) -> Result,
-    connectWithSendTransaction: suspend (amount: String, from: String, to: String) -> Result
+    sendTransaction: suspend (value: String, from: String, to: String) -> Result,
+    connectWithSendTransaction: suspend (value: String, from: String, to: String) -> Result
 ) {
     var amount by remember { mutableStateOf("0x01") }
     var from by remember { mutableStateOf(ethereumState.selectedAddress) }

--- a/app/src/main/java/com/metamask/dapp/SendTransactionScreen.kt
+++ b/app/src/main/java/com/metamask/dapp/SendTransactionScreen.kt
@@ -37,7 +37,7 @@ fun SendTransactionScreen(
     sendTransaction: suspend (value: String, from: String, to: String) -> Result,
     connectWithSendTransaction: suspend (value: String, from: String, to: String) -> Result
 ) {
-    var amount by remember { mutableStateOf("0x01") }
+    var value by remember { mutableStateOf("0x8ac7230489e80000") }
     var from by remember { mutableStateOf(ethereumState.selectedAddress) }
     var to by remember { mutableStateOf("0x0000000000000000000000000000000000000000") }
     var sendResult by remember { mutableStateOf("") }
@@ -67,7 +67,7 @@ fun SendTransactionScreen(
                     .height(48.dp)
             ) {
                 Text(
-                    text = "Amount:",
+                    text = "Value:",
                     fontSize = 14.sp,
                     fontWeight = FontWeight.Bold,
                     textAlign = TextAlign.Start,
@@ -87,10 +87,10 @@ fun SendTransactionScreen(
                         }
                 ) {
                     BasicTextField(
-                        value = amount,
+                        value = value,
                         textStyle = TextStyle(color = if (isSystemInDarkTheme()) { Color.White} else { Color.Black}),
                         onValueChange = {
-                            amount = it
+                            value = it
                         },
                         modifier = Modifier
                             .padding(start = 8.dp, top = 16.dp, end = 8.dp, bottom = 0.dp)
@@ -184,7 +184,7 @@ fun SendTransactionScreen(
             if (isConnectWith) {
                 DappButton(buttonText = stringResource(R.string.connect_with_send)) {
                     coroutineScope.launch {
-                        when (val result = connectWithSendTransaction(amount, from, to)) {
+                        when (val result = connectWithSendTransaction(value, from, to)) {
                             is Result.Success.Item -> {
                                 errorMessage = null
                                 sendResult = result.value
@@ -199,7 +199,7 @@ fun SendTransactionScreen(
             } else {
                 DappButton(buttonText = stringResource(R.string.send)) {
                     coroutineScope.launch {
-                        when (val result = sendTransaction(amount, from, to)) {
+                        when (val result = sendTransaction(value, from, to)) {
                             is Result.Success.Item -> {
                                 errorMessage = null
                                 sendResult = result.value

--- a/metamask-android-sdk/build.gradle
+++ b/metamask-android-sdk/build.gradle
@@ -15,7 +15,7 @@ android {
         targetSdk 33
 
         ext.versionCode = 1
-        ext.versionName = "0.6.1"
+        ext.versionName = "0.6.2"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles 'consumer-rules.pro'
@@ -68,7 +68,7 @@ dependencies {
 
 ext {
     PUBLISH_GROUP_ID = 'io.metamask.androidsdk'
-    PUBLISH_VERSION = '0.6.1'
+    PUBLISH_VERSION = '0.6.2'
     PUBLISH_ARTIFACT_ID = 'metamask-android-sdk'
 }
 

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/CommunicationClient.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/CommunicationClient.kt
@@ -330,7 +330,7 @@ class CommunicationClient(
         val errorCode = errorMap["code"] as? Double ?: -1
         val code = errorCode.toInt()
         val message = errorMap["message"] as? String ?: ErrorType.message(code)
-        logger.error("CommunicationClient:: Got error $message")
+        logger.error("CommunicationClient:: Got error $error")
         completeRequest(requestId, Result.Error(RequestError(code, message)))
         return true
     }
@@ -476,6 +476,7 @@ class CommunicationClient(
         val requestInfoJson = Gson().toJson(requestInfo)
 
         logger.log("CommunicationClient:: Sending originator info: $requestInfoJson")
+        logger.log("CommunicationClient:: SessionId $sessionId")
 
         val payload = keyExchange.encrypt(requestInfoJson)
 

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/Ethereum.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/Ethereum.kt
@@ -259,11 +259,11 @@ class Ethereum (
         ethereumRequest(method = EthereumMethod.ETH_SIGN_TYPED_DATA_V4, params = listOf(address, typedData), callback)
     }
 
-    fun sendTransaction(from: String, to: String, amount: String, callback: ((Result) -> Unit)?) {
+    fun sendTransaction(from: String, to: String, value: String, callback: ((Result) -> Unit)?) {
         ethereumRequest(method = EthereumMethod.ETH_SEND_TRANSACTION, params = listOf(mutableMapOf(
             "from" to from,
             "to" to to,
-            "amount" to amount
+            "value" to value
         )), callback)
     }
 

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/EthereumFlow.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/EthereumFlow.kt
@@ -29,7 +29,7 @@ interface EthereumFlowWrapper {
     suspend fun getBlockTransactionCountByHash(blockHash: String) : Result
     suspend fun getBlockTransactionCountByNumber(blockNumber: String) : Result
     suspend fun getTransactionCount(address: String, tagOrblockNumber: String) : Result
-    suspend fun sendTransaction(from: String, to: String, amount: String) : Result
+    suspend fun sendTransaction(from: String, to: String, value: String) : Result
 
     suspend fun switchEthereumChain(targetChainId: String) : Result
     suspend fun addEthereumChain(chainId: String,
@@ -139,11 +139,11 @@ constructor(
     override suspend fun ethSignTypedDataV4(typedData: Any, address: String) : Result =
         ethereumRequest(method = EthereumMethod.ETH_SIGN_TYPED_DATA_V4, params = listOf(address, typedData))
 
-    override suspend fun sendTransaction(from: String, to: String, amount: String) : Result =
+    override suspend fun sendTransaction(from: String, to: String, value: String) : Result =
         ethereumRequest(method = EthereumMethod.ETH_SEND_TRANSACTION, params = listOf(mapOf(
             "from" to from,
             "to" to to,
-            "value" to amount
+            "value" to value
         )))
 
     override suspend fun sendRawTransaction(signedTransaction: String) : Result =

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/EthereumFlow.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/EthereumFlow.kt
@@ -143,7 +143,7 @@ constructor(
         ethereumRequest(method = EthereumMethod.ETH_SEND_TRANSACTION, params = listOf(mapOf(
             "from" to from,
             "to" to to,
-            "amount" to amount
+            "value" to amount
         )))
 
     override suspend fun sendRawTransaction(signedTransaction: String) : Result =

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/SDKInfo.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/SDKInfo.kt
@@ -1,6 +1,6 @@
 package io.metamask.androidsdk
 
 object SDKInfo {
-    const val VERSION = "0.6.1"
+    const val VERSION = "0.6.2"
     const val PLATFORM = "android"
 }


### PR DESCRIPTION
This PR fixes the `sendTransaction` convenience method. Previously it used `amount` instead of `value` for the value field which was incorrect.