### PR TITLE
feature: add ability to specify read-only rpc map

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ code to your project file:
 class SomeModel(context: Context) {
     
     val dappMetadata = DappMetadata("Droid Dapp", "https://www.droiddapp.io")
-    val infuraAPIKey = "1234567890" // We use Infura API for read-only RPCs for a seamless user experience 
-    
+    val infuraAPIKey = "1234567890" // To use the Infura API to make read-only requests, specify your Infura API key using the `infuraAPIKey` option in `SDKOptions`
+    val readonlyRPCMap = mapOf("0x1" to "hptts://www.testrpc.com") // To use your own node (for example, with Hardhat) to make read-only requests, specify your node's chain ID and RPC URL using the `readonlyRPCMap` option
+
     // A) Using callbacks
-    val ethereum = Ethereum(context, dappMetadata, SDKOptions(infuraAPIKey))
+    val ethereum = Ethereum(context, dappMetadata, SDKOptions(infuraAPIKey, readonlyRPCMap))
     
     // This is the same as calling eth_requestAccounts
     ethereum.connect() { result ->

--- a/README.md
+++ b/README.md
@@ -71,8 +71,12 @@ code to your project file:
 class SomeModel(context: Context) {
     
     val dappMetadata = DappMetadata("Droid Dapp", "https://www.droiddapp.io")
-    val infuraAPIKey = "1234567890" // To use the Infura API to make read-only requests, specify your Infura API key using the `infuraAPIKey` option in `SDKOptions`
-    val readonlyRPCMap = mapOf("0x1" to "hptts://www.testrpc.com") // To use your own node (for example, with Hardhat) to make read-only requests, specify your node's chain ID and RPC URL using the `readonlyRPCMap` option
+    
+    // To use the Infura API to make read-only requests, specify your Infura API key using the `infuraAPIKey` option in `SDKOptions`
+    val infuraAPIKey = "1234567890"
+
+    // To use your own node (for example, with Hardhat) to make read-only requests, specify your node's chain ID and RPC URL 
+    val readonlyRPCMap = mapOf("0x1" to "hptts://www.testrpc.com") using the `readonlyRPCMap` option
 
     // A) Using callbacks
     val ethereum = Ethereum(context, dappMetadata, SDKOptions(infuraAPIKey, readonlyRPCMap))

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/ReadOnlyRPCProvider.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/ReadOnlyRPCProvider.kt
@@ -2,7 +2,7 @@ package io.metamask.androidsdk
 
 import org.json.JSONObject
 
-open class InfuraProvider(private val infuraAPIKey: String?, readonlyRPCMap: Map<String, String>?, private val logger: Logger = DefaultLogger) {
+open class ReadOnlyRPCProvider(private val infuraAPIKey: String?, readonlyRPCMap: Map<String, String>?, private val logger: Logger = DefaultLogger) {
     val rpcUrls: Map<String, String> = when {
         readonlyRPCMap != null && infuraAPIKey != null -> {
             // Merge infuraReadonlyRPCMap with readonlyRPCMap, overriding infura's keys if they are present in readonlyRPCMap

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/ReadOnlyRPCProvider.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/ReadOnlyRPCProvider.kt
@@ -23,7 +23,7 @@ open class ReadOnlyRPCProvider(private val infuraAPIKey: String?, readonlyRPCMap
         return mapOf(
             // ###### Ethereum ######
             // Mainnet
-            "0x1" to "https://mainnet.infura.io/v3/${infuraAPIKey}",
+            //"0x1" to "https://mainnet.infura.io/v3/${infuraAPIKey}",
     
             // Sepolia 11155111
             "0x2a" to "https://sepolia.infura.io/v3/${infuraAPIKey}",
@@ -99,7 +99,13 @@ open class ReadOnlyRPCProvider(private val infuraAPIKey: String?, readonlyRPCMap
         params["id"] = request.id
         params["params"] = request.params ?: listOf<String>()
 
-        httpClient.newCall("${rpcUrls[chainId]}", parameters = params) { response, ioException ->
+        val endpoint = rpcUrls[chainId]
+        if (endpoint == null) {
+            callback?.invoke(Result.Error(RequestError(-1, "There is no defined network for chainId $chainId, please provide it via readonlyRPCMap")))
+            return
+        }
+
+        httpClient.newCall(endpoint, parameters = params) { response, ioException ->
             if (response != null) {
                 logger.log("InfuraProvider:: response $response")
                 try {

--- a/metamask-android-sdk/src/main/java/io/metamask/androidsdk/SDKOptions.kt
+++ b/metamask-android-sdk/src/main/java/io/metamask/androidsdk/SDKOptions.kt
@@ -1,3 +1,6 @@
 package io.metamask.androidsdk
 
-data class SDKOptions(val infuraAPIKey: String)
+data class SDKOptions(
+    val infuraAPIKey: String?,
+    var readonlyRPCMap: Map<String, String>?
+)

--- a/metamask-android-sdk/src/test/java/io/metamask/androidsdk/EthereumTests.kt
+++ b/metamask-android-sdk/src/test/java/io/metamask/androidsdk/EthereumTests.kt
@@ -7,7 +7,6 @@ import android.os.IBinder
 import io.metamask.androidsdk.KeyExchangeMessageType.*
 import io.metamask.nativesdk.IMessegeService
 import io.metamask.androidsdk.Event.*
-import io.metamask.androidsdk.MockInfuraProvider
 import org.json.JSONObject
 import org.junit.Assert.*
 import org.junit.Before
@@ -43,7 +42,7 @@ class EthereumTests {
     private lateinit var ethereum: Ethereum
     private lateinit var mockStorage: MockKeyStorage
     private lateinit var communicationClient: CommunicationClient
-    private lateinit var mockInfuraProvider: MockInfuraProvider
+    private lateinit var mockInfuraProvider: MockReadOnlyRPCProvider
 
     @Before
     fun setup() {
@@ -60,7 +59,7 @@ class EthereumTests {
         keyExchange = KeyExchange(mockCrypto, logger)
         mockStorage = MockKeyStorage()
         sessionManager = SessionManager(mockStorage)
-        mockInfuraProvider = MockInfuraProvider(SDKOptions(infuraAPIKey = "01234567").infuraAPIKey, logger)
+        mockInfuraProvider = MockReadOnlyRPCProvider("01234567", null, logger)
 
         mockCommunicationClientModule = MockCommunicationClientModule(
             context,
@@ -75,7 +74,7 @@ class EthereumTests {
         ethereum = Ethereum(
             context,
             DappMetadata("testApp","http://www.testapp.com", iconUrl = null, base64Icon = null),
-            sdkOptions = SDKOptions(infuraAPIKey = "01234567"),
+            sdkOptions = SDKOptions(infuraAPIKey = "01234567", readonlyRPCMap = null),
             logger,
             mockCommunicationClientModule,
             mockInfuraProvider

--- a/metamask-android-sdk/src/test/java/io/metamask/androidsdk/MockReadOnlyRPCProvider.kt
+++ b/metamask-android-sdk/src/test/java/io/metamask/androidsdk/MockReadOnlyRPCProvider.kt
@@ -1,6 +1,6 @@
 package io.metamask.androidsdk
 
-class MockInfuraProvider(private val infuraAPIKey: String, private val logger: Logger = TestLogger) : InfuraProvider(infuraAPIKey, logger) {
+class MockReadOnlyRPCProvider(private val infuraAPIKey: String, private val readOnlyRPCMap: Map<String, String>?, private val logger: Logger = TestLogger) : ReadOnlyRPCProvider(infuraAPIKey, readOnlyRPCMap, logger) {
     var mockResponse: String? = null  // This can hold the mock response for the request.
 
     override fun makeRequest(request: RpcRequest, chainId: String, dappMetadata: DappMetadata, callback: ((Result) -> Unit)?) {


### PR DESCRIPTION
This PR adds the ability to use both the Infura API and custom nodes to make read-only requests by specifying both the [infuraAPIKey](https://docs.metamask.io/wallet/reference/sdk-js-options/#infuraapikey) and [readonlyRPCMap](https://docs.metamask.io/wallet/reference/sdk-js-options/#readonlyrpcmap) options when instantiating the SDK in the dapp. It previously only supported the Infura API but not custom nodes.